### PR TITLE
Output média móvel construído.

### DIFF
--- a/algo_movingaverage.py
+++ b/algo_movingaverage.py
@@ -15,6 +15,7 @@ def ma_plot(series, window):
     return filename
 
 def data_ma(series, window):
-    ma = series.rolling(window).mean()
+    ma = list(series.rolling(window).mean().values)
+    print (ma)
     # ma = list(pd.rolling_mean(series, window))
     return ma

--- a/templates/algorithms_acf_output.html
+++ b/templates/algorithms_acf_output.html
@@ -18,7 +18,7 @@
 
 <div>
   <h5>Gráfico</h5>
-  <img src="{{ image }}" class="rounded mx-auto d-block" alt="Gráfico ACF">
+  <img src="{{ image }}" class="img-fluid img-rounded mx-auto d-block" alt="Gráfico ACF">
 </div>
 
 <h6>Tabelas</h6>

--- a/templates/algorithms_decomposition_output.html
+++ b/templates/algorithms_decomposition_output.html
@@ -17,7 +17,7 @@
 
 <div>
   <h5>Gráfico</h5>
-  <img src="{{ image }}" class="rounded mx-auto d-block" alt="Gráfico de Decomposição">
+  <img src="{{ image }}" class="img-fluid img-rounded mx-auto d-block" alt="Gráfico Decomposição">
 </div>
 
 <h6>Tabelas</h6>

--- a/templates/algorithms_movingaverage_output.html
+++ b/templates/algorithms_movingaverage_output.html
@@ -17,7 +17,7 @@
 
 <div>
   <h5>Gráfico</h5>
-  <img src="{{ image }}" class="rounded mx-auto d-block" alt="Gráfico Média Móvel">
+  <img src="{{ image }}" class="img-fluid img-rounded mx-auto d-block" alt="Gráfico Média Móvel">
 </div>
 
 <h6>Tabelas</h6>
@@ -34,7 +34,7 @@
         {% for i in range(data_ma|length) %}
         <tr class="d-flex">
           <td class="col-3">{{ i }}</td>
-          <td class="col-9">{{ data_ma[i] }}</td>
+          <td class="col-9">{{ data_ma[i][0] }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/algorithms_pacf_output.html
+++ b/templates/algorithms_pacf_output.html
@@ -17,7 +17,7 @@
 
 <div>
   <h5>Gráfico</h5>
-  <img src="{{ image }}" class="rounded mx-auto d-block" alt="Gráfico ACF">
+  <img src="{{ image }}" class="img-fluid img-rounded mx-auto d-block" alt="Gráfico PACF">
 </div>
 
 <h6>Tabelas</h6>


### PR DESCRIPTION
Formato da imagem ajustado (responsivo e respeitando largura da coluna). Tabela sendo preenchida. Falta preecher índices propriamente.